### PR TITLE
Add email notification interface for shop changes

### DIFF
--- a/PinChecker/Program.cs
+++ b/PinChecker/Program.cs
@@ -44,6 +44,7 @@ services.AddScoped<ICosmosDb, CosmosDb>();
 services.AddScoped<IPlaywrightService>(sp => new PotatoPinsService(Options.Create(sp.GetRequiredService<IOptionsMonitor<PlaywrightServiceConfig>>().Get(Constants.ConfigPotatoPins))));
 
 // Register Repositories
+services.AddScoped<IEmailRepository, EmailRepository>();
 services.AddScoped<IShopRepository, ShopRepository>();
 
 // Build Service Provider
@@ -54,6 +55,7 @@ using var scope = serviceProvider.CreateScope();
 Console.WriteLine("Starting");
 try
 {
+    var emailRepository = scope.ServiceProvider.GetRequiredService<IEmailRepository>();
     var shopRepository = scope.ServiceProvider.GetRequiredService<IShopRepository>();
     
     List<ShopChanges> shopChanges = [.. (await shopRepository.GetShopChangesAsync())];
@@ -62,9 +64,12 @@ try
         Console.WriteLine("No changes detected in any shop.");
     else
     {
+        // Send email with the changes
+        emailRepository.SendShopChangesEmail(shopChanges);
+        Console.WriteLine($"Email sent with changes from {shopChanges.Count} shop(s).");
 
         // Log the changes once the email has been successfully sent
-        await shopRepository.UpdateShopRecordsAsync();
+        //await shopRepository.UpdateShopRecordsAsync();
     }
 }
 catch (Exception ex)

--- a/PinChecker/Repositories/IEmailRepository.cs
+++ b/PinChecker/Repositories/IEmailRepository.cs
@@ -1,0 +1,8 @@
+﻿using PinChecker.Models;
+
+namespace PinChecker.Repositories;
+
+public interface IEmailRepository
+{
+    void SendShopChangesEmail(List<ShopChanges> changes);
+}


### PR DESCRIPTION
Updated Program.cs to register IEmailRepository and send emails with shop changes. Commented out the asynchronous update of shop records after sending the email. Introduced IEmailRepository interface in IEmailRepository.cs with a method for sending shop change emails.